### PR TITLE
Auto-detect column types in SDTM transformer

### DIFF
--- a/tests/test_sdtm_transformer.py
+++ b/tests/test_sdtm_transformer.py
@@ -75,8 +75,6 @@ def test_preprocessor_builds_vocab_and_sequences(example_dataframe):
     preprocessor = SDTMPreprocessor(
         subject_id_col="usubjid",
         sequence_col="exseq",
-        continuous_cols=["exdose", "exstdy"],
-        bin_counts={"exdose": 5, "exstdy": 5},
     )
 
     preprocessor.fit(example_dataframe)
@@ -85,6 +83,8 @@ def test_preprocessor_builds_vocab_and_sequences(example_dataframe):
     assert preprocessor.vocab["[SOS]"] == 1
     assert "arm__A" in preprocessor.vocab
     assert any(key.startswith("exdose__") for key in preprocessor.vocab)
+    assert preprocessor.column_types["exdose"] == "continuous"
+    assert preprocessor.column_types["arm"] == "categorical"
 
     assert len(sequences) == 2
     first_sequence = sequences[0]


### PR DESCRIPTION
## Summary
- automatically infer continuous columns during preprocessing, including bin edge tracking for synthesis
- generate numeric outputs for continuous tokens when synthesizing records
- update tests to validate automatic column type detection metadata

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68de92add8b8832c9963654ff298333a